### PR TITLE
Fix async `iter`

### DIFF
--- a/src/async.ts
+++ b/src/async.ts
@@ -101,7 +101,7 @@ export async function next<T, U>(
  */
 export function iter<T>(iterable: AnyIterable<T>): AnyIterator<T> {
   return ((iterable as AsyncIterable<T>)[Symbol.asyncIterator] ||
-    (iterable as Iterable<T>)[Symbol.iterator])();
+    (iterable as Iterable<T>)[Symbol.iterator]).call(iterable);
 }
 
 /**


### PR DESCRIPTION
This fixes the async `iter` function and all async functions which depend on it.

Otherwise you get this TypeError when using something like `tee`:

```
TypeError: Cannot read property 'next' of undefined
    at gen_1 (/example-project/node_modules/iterative/src/async.ts:467:4)
    at gen_1.next (<anonymous>)
    at resume (/example-project/node_modules/iterative/dist/async.js:23:44)
    at /example-project/node_modules/iterative/dist/async.js:22:121
    at new Promise (<anonymous>)
    at Object.i.<computed> [as next] (/example-project/node_modules/iterative/dist/async.js:22:63)
```